### PR TITLE
add preference to change recovery pause duration

### DIFF
--- a/lib/i18n/de_DE.json
+++ b/lib/i18n/de_DE.json
@@ -82,5 +82,6 @@
     "tempo_very_fast": "Sehr Schnell",
     "tempo_fast": "Schnell",
     "tempo_medium": "Mittel",
-    "tempo_slow": "Langsam"
+    "tempo_slow": "Langsam",
+    "recovery_pause_label": "Erholungspausendauer"
 }

--- a/lib/i18n/en_US.json
+++ b/lib/i18n/en_US.json
@@ -98,6 +98,8 @@
   "tempo_very_fast": "Very Fast",
   "tempo_fast": "Fast",
   "tempo_medium": "Medium",
-  "tempo_slow": "Slow"
+  "tempo_slow": "Slow",
+
+  "recovery_pause_label": "Recovery Pause Duration"
 }
   

--- a/lib/i18n/es_ES.json
+++ b/lib/i18n/es_ES.json
@@ -82,5 +82,6 @@
     "tempo_very_fast": "Muy Rápido",
     "tempo_fast": "Rápido",
     "tempo_medium": "Medio",
-    "tempo_slow": "Lento"
+    "tempo_slow": "Lento",
+    "recovery_pause_label": "Duración de la Pausa de Recuperación"
 }

--- a/lib/i18n/fr_FR.json
+++ b/lib/i18n/fr_FR.json
@@ -82,5 +82,6 @@
     "tempo_very_fast": "Très Rapide",
     "tempo_fast": "Rapide",
     "tempo_medium": "Moyen",
-    "tempo_slow": "Lent"
+    "tempo_slow": "Lent",
+    "recovery_pause_label": "Durée de la Pause de Récupération"
 }

--- a/lib/i18n/id_ID.json
+++ b/lib/i18n/id_ID.json
@@ -82,5 +82,6 @@
     "tempo_very_fast": "Sangat Cepat",
     "tempo_fast": "Cepat",
     "tempo_medium": "Sedang",
-    "tempo_slow": "Lambat"
+    "tempo_slow": "Lambat",
+    "recovery_pause_label": "Durasi Jeda Pemulihan"
 }

--- a/lib/i18n/it_IT.json
+++ b/lib/i18n/it_IT.json
@@ -82,5 +82,6 @@
     "tempo_very_fast": "Molto Veloce",
     "tempo_fast": "Veloce",
     "tempo_medium": "Medio",
-    "tempo_slow": "Lento"
+    "tempo_slow": "Lento",
+    "recovery_pause_label": "Durata Pausa di Recupero"
 }

--- a/lib/i18n/pl_PL.json
+++ b/lib/i18n/pl_PL.json
@@ -98,5 +98,7 @@
   "tempo_very_fast": "Bardzo szybkie",
   "tempo_fast": "Szybkie",
   "tempo_medium": "Średnie",
-  "tempo_slow": "Wolne"
+  "tempo_slow": "Wolne",
+
+  "recovery_pause_label": "Czas przerwy na odpoczynek"
 }

--- a/lib/i18n/ru_RU.json
+++ b/lib/i18n/ru_RU.json
@@ -82,5 +82,6 @@
     "tempo_very_fast": "Очень Быстро",
     "tempo_fast": "Быстро",
     "tempo_medium": "Средне",
-    "tempo_slow": "Медленно"
+    "tempo_slow": "Медленно",
+    "recovery_pause_label": "Длительность паузы восстановления"
 }

--- a/lib/i18n/zh_CN.json
+++ b/lib/i18n/zh_CN.json
@@ -82,5 +82,6 @@
     "tempo_very_fast": "非常快",
     "tempo_fast": "快",
     "tempo_medium": "中等",
-    "tempo_slow": "慢"
+    "tempo_slow": "慢",
+    "recovery_pause_label": "恢复暂停时间"
 }

--- a/lib/models/preferences.dart
+++ b/lib/models/preferences.dart
@@ -5,6 +5,7 @@ class Preferences {
   int breaths;
   int volume;
   bool screenAlwaysOn;
+  int recoveryPause;
 
   Preferences({
     this.notificationEnabled = true,
@@ -12,8 +13,8 @@ class Preferences {
     this.tempo = 1668,
     this.breaths = 30,
     this.volume = 100, 
-    this.screenAlwaysOn = true
-
+    this.screenAlwaysOn = true,
+    this.recoveryPause = 15
   });
 
   Map<String, dynamic> toJson() {
@@ -23,7 +24,8 @@ class Preferences {
       'tempo': tempo,
       'breaths': breaths,
       'volume': volume,
-      'screenAlwaysOn': screenAlwaysOn
+      'screenAlwaysOn': screenAlwaysOn,
+      'recoveryPause': recoveryPause
     };
   }
 
@@ -35,6 +37,7 @@ class Preferences {
       breaths: json['breaths'] ?? 30,
       volume: json['volume'] ?? 90,
       screenAlwaysOn: json['screenAlwaysOn'] ?? true,
+      recoveryPause: json['recoveryPause'] ?? 15,
     );
   }
 }

--- a/lib/screens/exercise/exercise_step3.dart
+++ b/lib/screens/exercise/exercise_step3.dart
@@ -24,6 +24,7 @@ class _ExerciseStep3State extends State<ExerciseStep3> {
   Duration tempoDuration = Duration(seconds: 2);
   String innerText = 'in';
   Timer? breathCycleTimer;
+  int recoveryPause = 15;
 
   @override
   void initState() {
@@ -35,9 +36,10 @@ class _ExerciseStep3State extends State<ExerciseStep3> {
 
   Future<void> _loadDataFromPreferences() async {
     final userProvider = Provider.of<UserProvider>(context, listen: false);
-    final preferences = await userProvider.loadUserPreferences(['volume']);
+    final preferences = await userProvider.loadUserPreferences(['volume', 'recoveryPause']);
     setState(() {
       volume = preferences.volume;
+      recoveryPause = preferences.recoveryPause;
     });
   }
 
@@ -62,15 +64,14 @@ class _ExerciseStep3State extends State<ExerciseStep3> {
   void startBreathCounting() {
     breathCycleTimer = Timer.periodic(Duration(seconds: 1), (timer) {
       if (animationControl == 'pause') return;
-      // Pause logic
       setState(() {
         customTicker++;
         if (customTicker < 2) {
           innerText = 'in';
-        } else if (customTicker < 17) {
-          innerText = (17 - customTicker).toString();
+        } else if (customTicker < recoveryPause + 2) {
+          innerText = (recoveryPause + 2 - customTicker).toString();
           animationControl = 'stop';
-        } else if (customTicker >= 17 && customTicker <= 18) {
+        } else if (customTicker >= recoveryPause + 2 && customTicker <= recoveryPause + 3) {
           innerText = 'out';
           animationControl = 'reverse';
         } else {

--- a/lib/widgets/breathing_configuration.dart
+++ b/lib/widgets/breathing_configuration.dart
@@ -15,6 +15,7 @@ class BreathingConfigurationState extends State<BreathingConfiguration> {
   int volume = 100;
   double secondsPerBreath = 1.668; // Default tempo in seconds
   String animationCommand = 'repeat';
+  int recoveryPause = 15;
 
   @override
   void initState() {
@@ -24,12 +25,13 @@ class BreathingConfigurationState extends State<BreathingConfiguration> {
 
   Future<void> _loadUserPreferences() async {
     final userProvider = Provider.of<UserProvider>(context, listen: false);
-    final prefs = await userProvider.loadUserPreferences(['breaths', 'tempo', 'volume']);
+    final prefs = await userProvider.loadUserPreferences(['breaths', 'tempo', 'volume', 'recoveryPause']);
 
     setState(() {
       secondsPerBreath = prefs.tempo / 1000; // Convert milliseconds to seconds
       breaths = prefs.breaths;
       volume = prefs.volume;
+      recoveryPause = prefs.recoveryPause;
     });
   }
 
@@ -39,6 +41,7 @@ class BreathingConfigurationState extends State<BreathingConfiguration> {
       tempo: (secondsPerBreath * 1000).round(), // Convert seconds to milliseconds
       breaths: breaths,
       volume: volume,
+      recoveryPause: recoveryPause,
     );
     userProvider.saveUserPreferences(preferences);
   }
@@ -66,6 +69,15 @@ class BreathingConfigurationState extends State<BreathingConfiguration> {
     });
     _updateUser();
   }
+
+  void _updateRecoveryPause(double newPause) {
+    setState(() {
+      recoveryPause = newPause.toInt();
+      animationCommand = 'repeat';
+    });
+    _updateUser();
+  }
+
   String _getTempoLabel(double seconds) {
     if (seconds < 1) return 'tempo_very_fast'.i18n();
     if (seconds < 1.5) return 'tempo_fast'.i18n();
@@ -139,6 +151,24 @@ class BreathingConfigurationState extends State<BreathingConfiguration> {
           value: breaths.toDouble(),
           onChanged: (dynamic value) {
             _updateBreaths(value);
+          },
+        ),
+        SizedBox(height: 10),
+        Text(
+          'recovery_pause_label'.i18n(),
+          style: TextStyle(
+            fontSize: 22.0,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        Slider(
+          min: 10.0,
+          max: 25.0,
+          label: '${recoveryPause}s',
+          divisions: 15,
+          value: recoveryPause.toDouble(),
+          onChanged: (value) {
+            _updateRecoveryPause(value);
           },
         ),
       ],


### PR DESCRIPTION
The feature adds a new preference which allows you to change breath pause after long hold from 15 seconds, to another value between 10 and 25 seconds.

That's my first try in flutter and dart with some help from LLM.

I've tested those changes on linux, works for me like a charm.

The changes are based on this issue https://github.com/naoxio/inbreeze/issues/53 and I plan to continue =)

About translations, they are also a product of auto translators, I can only be sure in English and Russian. If you can contribute to it somehow, that would be great. Otherwise, they should be good enough.