### PR TITLE
do not play if volume is zero

### DIFF
--- a/lib/utils/audio_player_service.dart
+++ b/lib/utils/audio_player_service.dart
@@ -49,6 +49,10 @@ class AudioPlayerService {
   }
 
 Future<void> play(String assetPath, double volume, String playerId) async {
+  if (volume == 0) {
+    return;
+  }
+
   try {
     await _session.setActive(true);
     var player = _players[playerId];


### PR DESCRIPTION
Should partially fix this https://github.com/naoxio/inbreeze/issues/52

I only tested it on Linux desktop because it's easier for me. It stopped spawning mpv process, so I suppose it'll not actually play any sound on Android in case volume is 0.