### PR TITLE
allow to click on hold animation to go to the next step

### DIFF
--- a/lib/screens/exercise/exercise_step2.dart
+++ b/lib/screens/exercise/exercise_step2.dart
@@ -98,7 +98,13 @@ class _ExerciseStep2State extends State<ExerciseStep2> {
               child: Center(
                 child: Padding(
                   padding: const EdgeInsets.all(16.0),
-                  child: CustomTimer(duration: duration),
+                  child: MouseRegion(
+                    cursor: SystemMouseCursors.click,
+                    child: GestureDetector(
+                      onTap: _navigateToNextExercise,
+                      child: CustomTimer(duration: duration),
+                    ),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
This is a feature request with it's implementation.

Most of the time when I use this app, I lie on the back with my eyes closed. I don't want to open them or to move at all, so it would be very convenient to me to hold the phone in my hand and know that I can stop holding and continue by pressing more or less any place on the screen.

This PR adds this functionality. With this code during the ExerciseStep2 or hold step if you tap on animation it'll navigate you to the next step.